### PR TITLE
fixes a problem when python site.sys.path contains non-real paths.

### DIFF
--- a/bob/buildout/extension.py
+++ b/bob/buildout/extension.py
@@ -195,7 +195,8 @@ class Extension:
           undo.append(lambda: os.close(fd))
 
           os.write(fd, (runsetup_template % dict(
-              paths=os.pathsep.join(tools.get_pythonpath(working_set, self.buildout, self.installer.prefixes)),
+              # we reverse the order because we want the user paths to be inserted last ([::-1]).
+              paths=os.pathsep.join(tools.get_pythonpath(working_set, self.buildout, self.installer.prefixes)[::-1]),
               setup=setup,
               setupdir=directory,
               __file__ = setup,

--- a/bob/buildout/tools.py
+++ b/bob/buildout/tools.py
@@ -242,7 +242,7 @@ def get_pythonpath(working_set, buildout, prefixes):
     prepend_path(zc.buildout.easy_install.setuptools_loc, paths)
 
   return [k for k in working_set.entries \
-      if k not in site_paths(buildout, prefixes)]
+      if os.path.realpath(k) not in site_paths(buildout, prefixes)]
 
 def get_prefixes(buildout):
   """Returns a list of prefixes set on the buildout section"""


### PR DESCRIPTION
Also, orders the paths correctly when they are inserted.